### PR TITLE
feat: add chdir support to update cwd on each gather

### DIFF
--- a/bin/ddc-source-shell_native/capture.fish
+++ b/bin/ddc-source-shell_native/capture.fish
@@ -1,16 +1,32 @@
 #!/usr/bin/env fish
 
-function main
-    while true
-        read --local user_input
+set --local MSG_CHDIR "chdir:"
+set --local MSG_INPUT "input:"
 
-        if test -n "$user_input"
-            # Only process non-empty input
-            complete -C "$user_input"
-        end
+set --local END_OF_COMPLETION "\n\x01EOC\x01\n"
 
-        echo "EOF" >&2
+set --local user_input
+while true
+    read --local message || break
+
+    switch $message
+        case "$MSG_CHDIR*"
+            # Change the current working directory
+            set --local new_cwd (string replace -r "^$MSG_CHDIR" "" "$message")
+            cd "$new_cwd"
+            continue
+        case "$MSG_INPUT*"
+            # Do completion
+            set user_input (string replace -r "^$MSG_INPUT" "" "$message")
+        case "*"
+            echo "error: invalid message: $message" >&2
+            exit 1
     end
-end
 
-main
+    begin
+        complete --do-complete "$user_input"
+        echo -ne $END_OF_COMPLETION
+    end >&1
+
+    set user_input
+end

--- a/bin/ddc-source-shell_native/capture.xonsh
+++ b/bin/ddc-source-shell_native/capture.xonsh
@@ -1,26 +1,41 @@
 #!/usr/bin/env xonsh
 
+import os
 import sys
-import xonsh.completer
+from xonsh.completer import Completer
 
-def main():
-    completer = xonsh.completer.Completer()
+MSG_CHDIR = "chdir:"
+MSG_INPUT = "input:"
+
+END_OF_COMPLETION = "\n\x01EOC\x01\n"
+
+try:
+    completer = Completer()
+    user_input = ""
     while True:
-        try:
-            multiline_text = input()
+        message = input()
 
-            completions = completer.complete(
-                "", "", 0, 0, {},
-                multiline_text=multiline_text,
-                cursor_index=len(multiline_text)
-            )[0]
+        if message.startswith(MSG_CHDIR):
+            # Change the current working directory
+            new_cwd = message[len(MSG_CHDIR):]
+            os.chdir(new_cwd)
+            continue
+        elif message.startswith(MSG_INPUT):
+            # Do completion
+            user_input = message[len(MSG_INPUT):]
+            pass
+        else:
+            print(f"error: invalid message: {message}", file=sys.stderr)
+            sys.exit(1)
 
-            for completion in completions:
-                print(completion)
-            print("EOF", file=sys.stderr)
-        except KeyboardInterrupt:
-            print("\nExiting...")
-            break
+        completions, _lprefix = completer.complete(
+            "", "", 0, 0, {},
+            multiline_text=user_input,
+            cursor_index=len(user_input)
+        )
 
-if __name__ == "__main__":
-    main()
+        print(*completions, sep="\n", end=END_OF_COMPLETION, flush=True)
+
+        user_input = ""
+except (KeyboardInterrupt, EOFError) as _:
+    pass

--- a/bin/ddc-source-shell_native/capture.zsh
+++ b/bin/ddc-source-shell_native/capture.zsh
@@ -6,32 +6,55 @@ local zpty_rcfile=${0:h}/zptyrc.zsh
 [[ -r $zpty_rcfile ]] || { echo "error: rcfile not found: $zpty_rcfile" >&2; exit 1; }
 
 # Spawn shell with non-blocking (-b) output
-zpty -b z zsh -f -i
+zpty -b z zsh --no-rcs --interactive
 
 # Line buffer for pty output
-local line
+local line=
 
 # Initialize shell settings before processing
 zpty -w z "source ${(qq)zpty_rcfile} && echo ok || exit 2"
 zpty -r -m z line '*ok'$'\r' || { echo "error: pty initialization failure" >&2; exit 2 }
 
-# Main loop to read from stdin and process completion
-local input
-while true; do
-    # Read input from stdin
-    IFS= read -r input || break
+# Constants
+MSG_CHDIR="chdir:"
+MSG_INPUT="input:"
 
-    zpty -t z || { echo "error: pty closed" >&2; exit 1 }
+END_OF_COMPLETION=$'\n\x01EOC\x01\n'
+
+ACCEPT_LINE=$'\C-J'
+COMPLETE_WORD=$'\C-I'
+KILL_BUFFER=$'\C-U'
+NULL_BYTE=$'\0'
+
+# Main loop to read from stdin and process completion
+local message=
+local user_input=
+while true; do
+    IFS= read -r message || break
+
+    case $message in
+        $MSG_CHDIR*)
+            # Change the current working directory in the pty
+            local new_cwd=${message#$MSG_CHDIR}
+            zpty -w -n z "${KILL_BUFFER}cd ${(qq)new_cwd}${ACCEPT_LINE}"
+            continue
+            ;;
+        $MSG_INPUT*)
+            # Do completion
+            user_input=${message#$MSG_INPUT}
+            ;;
+        *)
+            echo "error: invalid message: $message" >&2
+            exit 1
+            ;;
+    esac
 
     # Trigger completion and send it to the pty
-    zpty -w -n z $'\C-U'"$input"$'\t'
+    zpty -w -n z "${KILL_BUFFER}${user_input}${COMPLETE_WORD}"
 
-    # Drop before the first null byte
-    zpty -r -m z line '*'$'\0' || { echo "error: pty read failure" >&2; exit 1 }
+    # Completion results are output between null bytes
+    zpty -r -m z line "*${NULL_BYTE}*${NULL_BYTE}" || { echo "error: pty read failure" >&2; exit 1 }
+    echo -nE - "${${(@0)line}[2]}${END_OF_COMPLETION}"
 
-    # Output the completion result
-    zpty -r -m z line '*'$'\0' || { echo "error: pty read failure" >&2; exit 1 }
-    echo -E - ${line%$'\0'}
-
-    echo "EOF" >&2
+    user_input=
 done

--- a/bin/ddc-source-shell_native/zptyrc.zsh
+++ b/bin/ddc-source-shell_native/zptyrc.zsh
@@ -4,18 +4,38 @@ typeset -gx CACHE_DIR=${XDG_CACHE_HOME:-"$HOME/.cache"}/ddc-source-shell_native
 
 [[ -d $CACHE_DIR ]] || mkdir -p "$CACHE_DIR"
 
-# No prompt!
-PROMPT=
-
 # Load completion system
 autoload -U compinit
 compinit -C -d "$CACHE_DIR/compdump"
 
-# Never run commands
-bindkey -r '^M'
-bindkey -r '^J'
+# Setup options
+HISTSIZE=0
+unset HISTFILE
+unset PROMPT
+unset PROMPT2
+unset PROMPT3
+unset PROMPT4
+unset RPROMPT
+unset RPROMPT2
+unsetopt beep
+setopt ignore_eof
+setopt single_line_zle
+
+# Keybindings
+bindkey -e
+bindkey -rR '^@'-'^_'
+bindkey -rp '^[' '^X'
+bindkey -r '^?'
+bindkey '^J' accept-line
+bindkey '^B' backward-char
 bindkey '^I' complete-word
 bindkey '^U' kill-buffer
+
+# Never run commands, except `cd`
+setopt debug_before_cmd
+DEBUGTRAP() {
+    [[ $ZSH_DEBUG_CMD == 'cd '* ]] || setopt err_exit
+}
 
 # Send a line with null-byte at the end before and after completions are output
 null-line () {


### PR DESCRIPTION
## Summary

- Add message protocol for chdir/input commands to shell capture scripts
- Implement working directory synchronization between Vim and shell processes
- Move EOF marker from stderr to stdout for reliable completion detection
- Add mutex-based synchronization for concurrent completion requests

## Key Changes

### Message Protocol Enhancement
- Introduced `MSG_CHDIR` and `MSG_INPUT` message types
- Unified message handling across all shell backends (fish, xonsh, zsh)

### Working Directory Synchronization
- Shell processes now update their working directory when Vim's cwd changes
- Particularly useful for file/directory completions in different project contexts

### Reliability Improvements
- Moved completion end marker from stderr to stdout for consistent detection
- Added mutex synchronization to prevent race conditions in concurrent completions
- Enhanced error handling and process communication

### Shell-Specific Updates
- **fish**: Use `complete --do-complete` for better completion handling
- **xonsh**: Improved completer initialization and result processing
- **zsh**: Enhanced zpty configuration with proper keybindings and safety measures

## Test Plan

- [x] Manually test with fish shell completion
- [x] Manually test with xonsh completion
- [x] Manually test with zsh completion  
- [x] Verify working directory changes are reflected in completions

## Compatibility

This change is backward compatible and doesn't affect the public API. The message protocol changes are internal to the shell capture scripts.